### PR TITLE
[FEAT] ADCP reader for rdadcp conversion in Matlab

### DIFF
--- a/ctd_tools/readers/__init__.py
+++ b/ctd_tools/readers/__init__.py
@@ -10,6 +10,8 @@ Available Readers:
 -----------------
 - NetCdfReader: Read NetCDF files
 - CsvReader: Read CSV files
+- AdcpMatlabRdadcpReader: Read ADCP Matlab files converted from rdadcp binaries
+- AdcpMatlabUhhdsReader: Read ADCP Matlab files converted from UHH DS binaries
 - RbrAsciiReader: Read RBR ASCII files
 - NortekAsciiReader: Read Nortek ASCII files
 - RbrRskLegacyReader: Read legacy RSK files
@@ -59,8 +61,8 @@ def __getattr__(name):
 # Build __all__ from registry  
 __all__ = [
     'AbstractReader',
-    'AdcpMatlabReader',
-    'AdcpMatlabReaderEfw',
+    'AdcpMatlabRdadcpReader',
+    'AdcpMatlabUhhdsReader',
     'CsvReader',
     'NetCdfReader', 
     'NortekAsciiReader',

--- a/ctd_tools/readers/adcp_matlab_rdadcp_reader.py
+++ b/ctd_tools/readers/adcp_matlab_rdadcp_reader.py
@@ -1,5 +1,5 @@
 """
-Module for reading ADCP (RDI/Teledyne Workhorse) data from MATLAB .mat files.
+Module for reading ADCP (RDI/Teledyne Workhorse) data from MATLAB .mat files converted from binary with rdadcp.
 """
 
 from __future__ import annotations
@@ -11,8 +11,8 @@ from datetime import datetime
 from ctd_tools.readers.base import AbstractReader
 
 
-class AdcpMatlabReaderEfw(AbstractReader):
-    """Reader which converts ADCP data stored in MATLAB .mat files into an xarray Dataset."""
+class AdcpMatlabRdadcpReader(AbstractReader):
+    """Reader which converts ADCP data stored in MATLAB .mat files converted from binary with rdadcp into an xarray Dataset."""
 
     def __init__(self, input_file, mapping=None, time_dim: str = "time",
                  bin_dim: str = "bin", beam_dim: str = "beam"):
@@ -334,11 +334,11 @@ class AdcpMatlabReaderEfw(AbstractReader):
 
     @staticmethod
     def format_key() -> str:
-        return "adcp-matlab-efw"
+        return "adcp-matlab-rdadcp"
 
     @staticmethod
     def format_name() -> str:
-        return "ADCP Matlab EFW"
+        return "ADCP Matlab rdadcp"
 
     @staticmethod
     def file_extension() -> str | None:

--- a/ctd_tools/readers/adcp_matlab_uhhds_reader.py
+++ b/ctd_tools/readers/adcp_matlab_uhhds_reader.py
@@ -1,3 +1,5 @@
+"""Module for reading ADCP data from MATLAB .mat files converted from binaries recorded from UHH during DS cruises."""
+
 from __future__ import annotations
 import numpy as np
 import xarray as xr
@@ -8,7 +10,7 @@ import re
 import ctd_tools.parameters as ctdparams
 from ctd_tools.readers.base import AbstractReader
 
-class AdcpMatlabReader(AbstractReader):
+class AdcpMatlabUhhdsReader(AbstractReader):
     """ Reads ADCP data from a matlab (.mat) file into a xarray Dataset. 
 
         This class is used to read ADCP files, which are stored in .mat files.
@@ -251,11 +253,11 @@ class AdcpMatlabReader(AbstractReader):
 
     @staticmethod
     def format_key() -> str:
-        return 'adcp-matlab'
+        return 'adcp-matlab-uhhds'
 
     @staticmethod
     def format_name() -> str:
-        return 'ADCP Matlab'
+        return 'ADCP Matlab UHH DS'
 
     @staticmethod
     def file_extension() -> str | None:

--- a/ctd_tools/readers/registry.py
+++ b/ctd_tools/readers/registry.py
@@ -103,17 +103,17 @@ READER_REGISTRY: List[ReaderMetadata] = [
         file_extension=None
     ),
     ReaderMetadata(
-        class_name="AdcpMatlabReader",
-        module_name=".adcp_matlab_reader",
-        format_name="ADCP Matlab",
-        format_key="adcp-matlab",
+        class_name="AdcpMatlabUhhdsReader",
+        module_name=".adcp_matlab_uhhds_reader",
+        format_name="ADCP Matlab UHH DS",
+        format_key="adcp-matlab-uhhds",
         file_extension= None
     ),
     ReaderMetadata(
-        class_name="AdcpMatlabReaderEfw",
-        module_name=".adcp_matlab_reader_efw",
-        format_name="ADCP Matlab EFW",
-        format_key="adcp-matlab-efw",
+        class_name="AdcpMatlabRdadcpReader",
+        module_name=".adcp_matlab_rdadcp_reader",
+        format_name="ADCP Matlab rdadcp",
+        format_key="adcp-matlab-rdadcp",
         file_extension= None
     ),
     ReaderMetadata(


### PR DESCRIPTION
This is a new reader called AdcpMatlabReaderEfw which works on files converted from binary with rdadcp in Matlab.