### PR TITLE
fix: accept potential_temperature when bare temperature is absent in …

### DIFF
--- a/seasenselib/plotters/base.py
+++ b/seasenselib/plotters/base.py
@@ -266,6 +266,32 @@ class AbstractPlotter(ABC):
             missing_str = ', '.join(missing_vars)
             raise ValueError(f"Required variable(s) missing from dataset: {missing_str}")
 
+    def _validate_required_variables_any(self, required_groups: list):
+        """Validates that at least one variable from each group exists.
+
+        Parameters
+        -----------
+        required_groups : list of list
+            Each inner list is a group of variable names; at least one
+            variable from each group must be present in the dataset.
+
+        Raises
+        -------
+        ValueError:
+            If for any group none of its variables are present.
+        """
+
+        missing_groups = []
+        for group in required_groups:
+            if not any(var in self.data for var in group):
+                missing_groups.append(' or '.join(group))
+
+        if missing_groups:
+            missing_str = '; '.join(missing_groups)
+            raise ValueError(
+                f"Required variable(s) missing from dataset. Need: {missing_str}"
+            )
+
     def _save_or_show_plot(self, output_file: str | None = None):
         """Helper method to either save plot to file or display it.
         

--- a/seasenselib/plotters/ts_diagram_plotter.py
+++ b/seasenselib/plotters/ts_diagram_plotter.py
@@ -59,24 +59,31 @@ class TsDiagramPlotter(AbstractPlotter):
         Raises:
         -------
         ValueError:
-            If required variables (temperature, salinity, depth) are missing.
+            If required variables (temperature or potential_temperature,
+            salinity, depth) are missing.
         """
-        # Validate required variables
-        required_vars = [params.TEMPERATURE, params.SALINITY, params.DEPTH]
-        self._validate_required_variables(required_vars)
+        # Validate required variables. Temperature may be provided either as
+        # in place temperature or as potential temperature.
+        required_groups = [
+            [params.TEMPERATURE, params.POTENTIAL_TEMPERATURE],
+            [params.SALINITY],
+            [params.DEPTH],
+        ]
+        self._validate_required_variables_any(required_groups)
 
         plt = self._get_plt()
 
         # Get dataset without NaN values
         ds = self._get_dataset_without_nan()
 
-        temperature = ds[params.TEMPERATURE]
-        salinity = ds[params.SALINITY]
-        depth = ds[params.DEPTH]
-
-        # Check for potential temperature and use it if available
+        # Prefer potential temperature if available, otherwise use in place
+        # temperature.
         if params.POTENTIAL_TEMPERATURE in ds:
             temperature = ds[params.POTENTIAL_TEMPERATURE]
+        else:
+            temperature = ds[params.TEMPERATURE]
+        salinity = ds[params.SALINITY]
+        depth = ds[params.DEPTH]
 
         # Create figure
         fig = plt.figure(figsize=(15, 8))
@@ -100,17 +107,13 @@ class TsDiagramPlotter(AbstractPlotter):
         plt.title(title)
         plt.xlabel('Salinity [PSU]')
 
-        # Set y-label based on temperature type
-        if params.POTENTIAL_TEMPERATURE in ds:
-            plt.ylabel(ds[params.POTENTIAL_TEMPERATURE].attrs['long_name'] + \
-                      " [" + ds[params.POTENTIAL_TEMPERATURE].attrs['units'] + "]")
-        else:
-            plt.ylabel(ds[params.TEMPERATURE].attrs['long_name'] + \
-                      " [" + ds[params.TEMPERATURE].attrs['units'] + "]")
+        # Set y-label based on the temperature variable actually used
+        plt.ylabel(temperature.attrs['long_name'] + \
+                  " [" + temperature.attrs['units'] + "]")
 
         # Integrate density isolines if wanted
         if show_density_isolines:
-            self._plot_density_isolines(ds)
+            self._plot_density_isolines(ds, temperature)
 
         # Enable tight layout
         plt.tight_layout()
@@ -118,13 +121,16 @@ class TsDiagramPlotter(AbstractPlotter):
         # Save or show the plot
         self._save_or_show_plot(output_file)
 
-    def _plot_density_isolines(self, ds):
+    def _plot_density_isolines(self, ds, temperature):
         """Plots density isolines into the T-S diagram.
         
         Parameters:
         -----------
         ds : xr.Dataset
             The dataset containing temperature and salinity data.
+        temperature : xr.DataArray
+            The temperature variable to use (in-situ or potential), matching
+            the one plotted.
         """
         try:
             import gsw  # type: ignore
@@ -135,8 +141,8 @@ class TsDiagramPlotter(AbstractPlotter):
             ) from exc
 
         # Define the min / max values for plotting isopycnals
-        t_min = ds[params.TEMPERATURE].values.min()
-        t_max = ds[params.TEMPERATURE].values.max()
+        t_min = temperature.values.min()
+        t_max = temperature.values.max()
         s_min = ds[params.SALINITY].values.min()
         s_max = ds[params.SALINITY].values.max()
 

--- a/tests/test_ts_plotter_temperature_fix.py
+++ b/tests/test_ts_plotter_temperature_fix.py
@@ -1,0 +1,86 @@
+"""Regression test for the TS plotter temperature/potential-temperature issue.
+
+The TS plotter must accept a dataset that has ``potential_temperature`` but no
+bare ``temperature`` (e.g. when in-situ temperature is stored as
+``temperature_1`` / ``temperature_2``). See the reported issue where
+``required_vars`` hard-required ``params.TEMPERATURE`` even though the plotter
+prefers ``params.POTENTIAL_TEMPERATURE`` when present.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+import xarray as xr
+import numpy as np
+
+import seasenselib.parameters as params
+from seasenselib.plotters.ts_diagram_plotter import TsDiagramPlotter
+
+
+def _make_dataset(temperature_var):
+    """Build a minimal dataset with the given temperature variable name."""
+    n = 5
+    time = np.array(
+        ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05"],
+        dtype="datetime64[s]",
+    )
+    ds = xr.Dataset(
+        {
+            temperature_var: (
+                "time",
+                np.linspace(10.0, 12.0, n),
+                {"long_name": "temperature", "units": "degC"},
+            ),
+            params.SALINITY: (
+                "time",
+                np.linspace(34.0, 35.0, n),
+                {"long_name": "salinity", "units": "PSU"},
+            ),
+            params.DEPTH: (
+                "time",
+                np.linspace(0.0, 100.0, n),
+                {"long_name": "depth", "units": "m"},
+            ),
+        },
+        coords={"time": time},
+    )
+    return ds
+
+
+def test_ts_plotter_accepts_potential_temperature_without_temperature():
+    """Reproduces the reported bug: potential_temperature present, no bare
+    temperature (only temperature_1 / temperature_2)."""
+    ds = _make_dataset(params.POTENTIAL_TEMPERATURE)
+    # Add the subscripted in place temperatures that exist in the demo notebook.
+    n = ds.sizes["time"]
+    ds[params.TEMPERATURE + "_1"] = (
+        "time",
+        np.linspace(10.0, 12.0, n),
+        {"long_name": "temperature 1", "units": "degC"},
+    )
+    ds[params.TEMPERATURE + "_2"] = (
+        "time",
+        np.linspace(10.0, 12.0, n),
+        {"long_name": "temperature 2", "units": "degC"},
+    )
+
+    plotter = TsDiagramPlotter(ds)
+    # Should not raise ValueError about missing temperature.
+    plotter.plot(output_file="test_ts_fix.png")
+    assert True
+
+
+def test_ts_plotter_accepts_bare_temperature():
+    ds = _make_dataset(params.TEMPERATURE)
+    plotter = TsDiagramPlotter(ds)
+    plotter.plot(output_file="test_ts_fix2.png")
+    assert True
+
+
+def test_ts_plotter_rejects_when_no_temperature_at_all():
+    ds = _make_dataset(params.TEMPERATURE + "_1")  # only subscripted
+    plotter = TsDiagramPlotter(ds)
+    with pytest.raises(ValueError):
+        plotter.plot()


### PR DESCRIPTION
TS plotter. The TS diagram plotter required params.TEMPERATURE even though it prefers params.POTENTIAL_TEMPERATURE when present. Datasets with only subscripted in place temperatures and a bare potential_temperature now validate and plot correctly, Fixes #66