### PR TITLE
fix: Nortek csv parsing east variables

### DIFF
--- a/seasenselib/readers/nortek_csv_reader.py
+++ b/seasenselib/readers/nortek_csv_reader.py
@@ -15,9 +15,19 @@ import xarray as xr
 import seasenselib.parameters as params
 from .base import AbstractReader
 
+<<<<<<< Updated upstream
 _NORTEK_VECTOR_COLUMN_RE = re.compile(
+=======
+
+_NORTEK_VECTOR_BEAM_COLUMN_RE = re.compile(
+>>>>>>> Stashed changes
     r"^(?P<kind>vel|velocity|amp|amplitude|corr|correlation)"
     r"(?:(?:Beam(?P<beam>\d+))|(?P<axis>East|North|Up))"
+    r"#(?P<cell>\d+)$",
+    re.IGNORECASE,
+)
+_NORTEK_VELOCITY_COMPONENT_COLUMN_RE = re.compile(
+    r"^(?P<kind>vel|velocity)(?P<component>East|North|Up|X|Y|Z)"
     r"#(?P<cell>\d+)$",
     re.IGNORECASE,
 )
@@ -36,11 +46,21 @@ _VELOCITY_AXIS_NAMES = {
     2: "y_velocity",
     3: "z_velocity",
 }
+_VELOCITY_AXIS_NAMES_BY_LABEL = {
+    "X": "x_velocity",
+    "Y": "y_velocity",
+    "Z": "z_velocity",
+}
 
 _VELOCITY_ENU_NAMES = {
     1: params.EAST_VELOCITY,
     2: params.NORTH_VELOCITY,
     3: params.UP_VELOCITY,
+}
+_VELOCITY_ENU_NAMES_BY_LABEL = {
+    "EAST": params.EAST_VELOCITY,
+    "NORTH": params.NORTH_VELOCITY,
+    "UP": params.UP_VELOCITY,
 }
 
 _COORDINATE_SYSTEM_CODES = {
@@ -131,6 +151,7 @@ def _first_command(commands: Dict[str, Any], name: str) -> Dict[str, Any]:
     return {}
 
 
+<<<<<<< Updated upstream
 def _parse_vector_column(source_column: str) -> Optional[Dict[str, int | str]]:
     """Parse a Nortek vector CSV column name into kind, beam_or_dir, and cell."""
     match = _NORTEK_VECTOR_COLUMN_RE.match(source_column.strip())
@@ -143,6 +164,34 @@ def _parse_vector_column(source_column: str) -> Optional[Dict[str, int | str]]:
         "axis": match.group("axis"),
         "cell": match.group("cell"),
     }
+=======
+def _parse_vector_column(
+    source_column: str,
+) -> Optional[Dict[str, int | str | None]]:
+    """Parse a Nortek vector CSV column name into kind, component, and cell."""
+    match = _NORTEK_VECTOR_BEAM_COLUMN_RE.match(source_column.strip())
+    if match:
+        return {
+            "kind": _NORTEK_VECTOR_KIND_ALIASES[match.group("kind").lower()],
+            "beam": int(match.group("beam")),
+            "axis": None,
+            "enu": None,
+            "cell": int(match.group("cell")),
+        }
+
+    match = _NORTEK_VELOCITY_COMPONENT_COLUMN_RE.match(source_column.strip())
+    if match:
+        component = match.group("component").upper()
+        return {
+            "kind": _NORTEK_VECTOR_KIND_ALIASES[match.group("kind").lower()],
+            "beam": None,
+            "axis": component if component in _VELOCITY_AXIS_NAMES_BY_LABEL else None,
+            "enu": component if component in _VELOCITY_ENU_NAMES_BY_LABEL else None,
+            "cell": int(match.group("cell")),
+        }
+
+    return None
+>>>>>>> Stashed changes
 
 
 def _first_existing_command(
@@ -384,6 +433,23 @@ def _coordinate_system_from_data(df: pd.DataFrame) -> Optional[str]:
     return None
 
 
+def _coordinate_system_from_vector_columns(df: pd.DataFrame) -> Optional[str]:
+    """Infer coordinate system from explicit velocity component column names."""
+    coordinate_systems = set()
+    for source_column in df.columns:
+        vector_column = _parse_vector_column(source_column)
+        if not vector_column or vector_column["kind"] != "vel":
+            continue
+        if vector_column.get("enu"):
+            coordinate_systems.add("ENU")
+        elif vector_column.get("axis"):
+            coordinate_systems.add("XYZ")
+
+    if len(coordinate_systems) == 1:
+        return coordinate_systems.pop()
+    return None
+
+
 def _units_for_source_column(
     source_column: str,
     variable_name: str,
@@ -403,12 +469,37 @@ def _units_for_source_column(
     return {}
 
 
+<<<<<<< Updated upstream
 def _velocity_variable_name(beam_or_axis: str, cell: int, coordinate_system: str) -> str:
     """Map Nortek velocity columns to coordinate-aware variable names."""
     if coordinate_system == "XYZ":
         variable_name = _VELOCITY_AXIS_NAMES.get(beam_or_axis, f"velocity_beam{beam_or_axis}")
     elif coordinate_system == "ENU":
         variable_name = _VELOCITY_ENU_NAMES.get(beam_or_axis, f"velocity_{beam_or_axis}")
+=======
+def _velocity_variable_name(
+    beam: Optional[int],
+    cell: int,
+    coordinate_system: str,
+    axis: Optional[str] = None,
+    enu: Optional[str] = None,
+) -> str:
+    """Map Nortek velocity columns to coordinate-aware variable names."""
+    if enu:
+        variable_name = _VELOCITY_ENU_NAMES_BY_LABEL.get(
+            enu,
+            f"velocity_{enu.lower()}",
+        )
+    elif axis:
+        variable_name = _VELOCITY_AXIS_NAMES_BY_LABEL.get(
+            axis,
+            f"{axis.lower()}_velocity",
+        )
+    elif coordinate_system == "XYZ" and beam is not None:
+        variable_name = _VELOCITY_AXIS_NAMES.get(beam, f"velocity_beam{beam}")
+    elif coordinate_system == "ENU" and beam is not None:
+        variable_name = _VELOCITY_ENU_NAMES.get(beam, f"velocity_beam{beam}")
+>>>>>>> Stashed changes
     else:
         variable_name = f"velocity_beam{beam_or_axis}"
 
@@ -417,7 +508,7 @@ def _velocity_variable_name(beam_or_axis: str, cell: int, coordinate_system: str
     return variable_name
 
 
-def _velocity_long_name(variable_name: str, beam: int, cell: int) -> str:
+def _velocity_long_name(variable_name: str, beam: int | str, cell: int) -> str:
     """Build a readable long name for velocity variables."""
     if variable_name.startswith("velocity_beam"):
         name = f"Velocity Beam {beam}"
@@ -462,6 +553,7 @@ def _build_nortek_csv_columns(
         if not vector_column:
             continue
 
+<<<<<<< Updated upstream
         kind = str(vector_column["kind"]).lower()
         if vector_column["beam"] is not None:
             beam = str(vector_column["beam"]).lower()
@@ -480,6 +572,31 @@ def _build_nortek_csv_columns(
             if axis is not None:
                 variable_name = _velocity_variable_name(axis, cell, coordinate_system)
                 long_name = _velocity_long_name(variable_name, axis, cell)
+=======
+        kind = str(vector_column["kind"])
+        beam = (
+            int(vector_column["beam"])
+            if vector_column["beam"] is not None
+            else None
+        )
+        axis = str(vector_column["axis"]) if vector_column["axis"] is not None else None
+        enu = str(vector_column["enu"]) if vector_column["enu"] is not None else None
+        cell = int(vector_column["cell"])
+
+        if kind == "vel":
+            variable_name = _velocity_variable_name(
+                beam,
+                cell,
+                coordinate_system,
+                axis=axis,
+                enu=enu,
+            )
+            long_name = _velocity_long_name(
+                variable_name,
+                beam if beam is not None else axis or enu or "",
+                cell,
+            )
+>>>>>>> Stashed changes
         elif kind == "amp":
             variable_name = f"amplitude_beam{beam}"
             if cell > 1:
@@ -506,6 +623,8 @@ def _build_nortek_csv_columns(
                 "description": units_entry.get("description"),
                 "long_name": long_name,
                 "beam": beam,
+                "axis": axis,
+                "enu": enu,
                 "cell": cell,
             }
         )
@@ -629,6 +748,7 @@ def _load_nortek_csv_dataset(
 
     coordinate_system = (
         _coordinate_system_from_data(df)
+        or _coordinate_system_from_vector_columns(df)
         or settings.get("coordinate_system")
         or "BEAM"
     )

--- a/seasenselib/readers/nortek_csv_reader.py
+++ b/seasenselib/readers/nortek_csv_reader.py
@@ -15,10 +15,10 @@ import xarray as xr
 import seasenselib.parameters as params
 from .base import AbstractReader
 
-
 _NORTEK_VECTOR_COLUMN_RE = re.compile(
     r"^(?P<kind>vel|velocity|amp|amplitude|corr|correlation)"
-    r"Beam(?P<beam>\d+)#(?P<cell>\d+)$",
+    r"(?:(?:Beam(?P<beam>\d+))|(?P<axis>East|North|Up))"
+    r"#(?P<cell>\d+)$",
     re.IGNORECASE,
 )
 
@@ -132,14 +132,15 @@ def _first_command(commands: Dict[str, Any], name: str) -> Dict[str, Any]:
 
 
 def _parse_vector_column(source_column: str) -> Optional[Dict[str, int | str]]:
-    """Parse a Nortek vector CSV column name into kind, beam, and cell."""
+    """Parse a Nortek vector CSV column name into kind, beam_or_dir, and cell."""
     match = _NORTEK_VECTOR_COLUMN_RE.match(source_column.strip())
     if not match:
         return None
 
     return {
-        "kind": _NORTEK_VECTOR_KIND_ALIASES[match.group("kind").lower()],
-        "beam": int(match.group("beam")),
+        "kind": _NORTEK_VECTOR_KIND_ALIASES[match.group("kind")],
+        "beam": str(match.group("beam")),
+        "axis": str(match.group("axis")),
         "cell": int(match.group("cell")),
     }
 
@@ -402,14 +403,14 @@ def _units_for_source_column(
     return {}
 
 
-def _velocity_variable_name(beam: int, cell: int, coordinate_system: str) -> str:
+def _velocity_variable_name(beam_or_axis: str, cell: int, coordinate_system: str) -> str:
     """Map Nortek velocity columns to coordinate-aware variable names."""
     if coordinate_system == "XYZ":
-        variable_name = _VELOCITY_AXIS_NAMES.get(beam, f"velocity_beam{beam}")
+        variable_name = _VELOCITY_AXIS_NAMES.get(beam_or_axis, f"velocity_beam{beam_or_axis}")
     elif coordinate_system == "ENU":
-        variable_name = _VELOCITY_ENU_NAMES.get(beam, f"velocity_beam{beam}")
+        variable_name = _VELOCITY_ENU_NAMES.get(beam_or_axis, f"velocity_{beam_or_axis}")
     else:
-        variable_name = f"velocity_beam{beam}"
+        variable_name = f"velocity_beam{beam_or_axis}"
 
     if cell > 1:
         return f"{variable_name}_cell{cell}"
@@ -461,13 +462,24 @@ def _build_nortek_csv_columns(
         if not vector_column:
             continue
 
-        kind = str(vector_column["kind"])
-        beam = int(vector_column["beam"])
+        kind = str(vector_column["kind"]).lower()
+        if vector_column["beam"] is not None:
+            beam = str(vector_column["beam"]).lower()
+        else:
+            beam = None
+        if vector_column["axis"] is not None:
+            axis = str(vector_column["axis"]).lower()
+        else:
+            axis = None
         cell = int(vector_column["cell"])
 
         if kind == "vel":
-            variable_name = _velocity_variable_name(beam, cell, coordinate_system)
-            long_name = _velocity_long_name(variable_name, beam, cell)
+            if beam is not None:
+                variable_name = _velocity_variable_name(beam, cell, coordinate_system)
+                long_name = _velocity_long_name(variable_name, beam, cell)
+            if axis is not None:
+                variable_name = _velocity_variable_name(axis, cell, coordinate_system)
+                long_name = _velocity_long_name(variable_name, axis, cell)
         elif kind == "amp":
             variable_name = f"amplitude_beam{beam}"
             if cell > 1:

--- a/seasenselib/readers/nortek_csv_reader.py
+++ b/seasenselib/readers/nortek_csv_reader.py
@@ -139,9 +139,9 @@ def _parse_vector_column(source_column: str) -> Optional[Dict[str, int | str]]:
 
     return {
         "kind": _NORTEK_VECTOR_KIND_ALIASES[match.group("kind")],
-        "beam": str(match.group("beam")),
-        "axis": str(match.group("axis")),
-        "cell": int(match.group("cell")),
+        "beam": match.group("beam"),
+        "axis": match.group("axis"),
+        "cell": match.group("cell"),
     }
 
 

--- a/seasenselib/readers/nortek_csv_reader.py
+++ b/seasenselib/readers/nortek_csv_reader.py
@@ -15,15 +15,10 @@ import xarray as xr
 import seasenselib.parameters as params
 from .base import AbstractReader
 
-<<<<<<< Updated upstream
-_NORTEK_VECTOR_COLUMN_RE = re.compile(
-=======
 
 _NORTEK_VECTOR_BEAM_COLUMN_RE = re.compile(
->>>>>>> Stashed changes
     r"^(?P<kind>vel|velocity|amp|amplitude|corr|correlation)"
-    r"(?:(?:Beam(?P<beam>\d+))|(?P<axis>East|North|Up))"
-    r"#(?P<cell>\d+)$",
+    r"Beam(?P<beam>\d+)#(?P<cell>\d+)$",
     re.IGNORECASE,
 )
 _NORTEK_VELOCITY_COMPONENT_COLUMN_RE = re.compile(
@@ -151,20 +146,6 @@ def _first_command(commands: Dict[str, Any], name: str) -> Dict[str, Any]:
     return {}
 
 
-<<<<<<< Updated upstream
-def _parse_vector_column(source_column: str) -> Optional[Dict[str, int | str]]:
-    """Parse a Nortek vector CSV column name into kind, beam_or_dir, and cell."""
-    match = _NORTEK_VECTOR_COLUMN_RE.match(source_column.strip())
-    if not match:
-        return None
-
-    return {
-        "kind": _NORTEK_VECTOR_KIND_ALIASES[match.group("kind")],
-        "beam": match.group("beam"),
-        "axis": match.group("axis"),
-        "cell": match.group("cell"),
-    }
-=======
 def _parse_vector_column(
     source_column: str,
 ) -> Optional[Dict[str, int | str | None]]:
@@ -191,7 +172,6 @@ def _parse_vector_column(
         }
 
     return None
->>>>>>> Stashed changes
 
 
 def _first_existing_command(
@@ -469,14 +449,6 @@ def _units_for_source_column(
     return {}
 
 
-<<<<<<< Updated upstream
-def _velocity_variable_name(beam_or_axis: str, cell: int, coordinate_system: str) -> str:
-    """Map Nortek velocity columns to coordinate-aware variable names."""
-    if coordinate_system == "XYZ":
-        variable_name = _VELOCITY_AXIS_NAMES.get(beam_or_axis, f"velocity_beam{beam_or_axis}")
-    elif coordinate_system == "ENU":
-        variable_name = _VELOCITY_ENU_NAMES.get(beam_or_axis, f"velocity_{beam_or_axis}")
-=======
 def _velocity_variable_name(
     beam: Optional[int],
     cell: int,
@@ -499,9 +471,8 @@ def _velocity_variable_name(
         variable_name = _VELOCITY_AXIS_NAMES.get(beam, f"velocity_beam{beam}")
     elif coordinate_system == "ENU" and beam is not None:
         variable_name = _VELOCITY_ENU_NAMES.get(beam, f"velocity_beam{beam}")
->>>>>>> Stashed changes
     else:
-        variable_name = f"velocity_beam{beam_or_axis}"
+        variable_name = f"velocity_beam{beam}"
 
     if cell > 1:
         return f"{variable_name}_cell{cell}"
@@ -553,26 +524,6 @@ def _build_nortek_csv_columns(
         if not vector_column:
             continue
 
-<<<<<<< Updated upstream
-        kind = str(vector_column["kind"]).lower()
-        if vector_column["beam"] is not None:
-            beam = str(vector_column["beam"]).lower()
-        else:
-            beam = None
-        if vector_column["axis"] is not None:
-            axis = str(vector_column["axis"]).lower()
-        else:
-            axis = None
-        cell = int(vector_column["cell"])
-
-        if kind == "vel":
-            if beam is not None:
-                variable_name = _velocity_variable_name(beam, cell, coordinate_system)
-                long_name = _velocity_long_name(variable_name, beam, cell)
-            if axis is not None:
-                variable_name = _velocity_variable_name(axis, cell, coordinate_system)
-                long_name = _velocity_long_name(variable_name, axis, cell)
-=======
         kind = str(vector_column["kind"])
         beam = (
             int(vector_column["beam"])
@@ -596,7 +547,6 @@ def _build_nortek_csv_columns(
                 beam if beam is not None else axis or enu or "",
                 cell,
             )
->>>>>>> Stashed changes
         elif kind == "amp":
             variable_name = f"amplitude_beam{beam}"
             if cell > 1:

--- a/tests/readers/test_nortek_csv_reader.py
+++ b/tests/readers/test_nortek_csv_reader.py
@@ -117,6 +117,35 @@ def _write_nortek_csv_with_coordinate_system(tmp_path, coordinate_system="ENU"):
     return csv_file
 
 
+def _write_nortek_csv_with_velocity_components(
+    tmp_path,
+    coordinate_system,
+    component_columns,
+):
+    csv_file = tmp_path / "Average Velocity DF3.csv"
+    csv_file.write_text(
+        "\n".join(
+            [
+                (
+                    "dateTime;serialNumber;temperature;coordinateSystem;"
+                    f"{component_columns[0]};{component_columns[1]};"
+                    f"{component_columns[2]};ampBeam1#1;corrBeam1#1"
+                ),
+                (
+                    "2026-07-11 12:00:00;A123;8.1;"
+                    f"{coordinate_system};0.11;0.21;0.31;55;98"
+                ),
+                (
+                    "2026-07-11 12:00:01;A123;8.2;"
+                    f"{coordinate_system};0.12;0.22;0.32;56;97"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return csv_file
+
+
 def test_load_nortek_csv_data_preserves_original_helper_logic(tmp_path):
     csv_file = _write_nortek_csv(tmp_path)
 
@@ -190,6 +219,61 @@ def test_nortek_csv_metadata_files_set_coordinate_system_and_units(tmp_path):
     assert ds["temperature"].attrs["units"] == "degC"
     assert ds["amplitude_beam1"].attrs["units"] == "dB"
     assert ds["correlation_beam1"].attrs["units"] == "%"
+
+
+def test_nortek_csv_beam_coordinate_system_keeps_beam_velocity_names(tmp_path):
+    csv_file = _write_nortek_csv_with_coordinate_system(tmp_path, "BEAM")
+    header_file, units_file = _write_nortek_csv_metadata_files(tmp_path, "BEAM")
+
+    ds = load_nortek_csv_data(
+        csv_file,
+        header_file=header_file,
+        units_file=units_file,
+    )
+
+    assert ds.attrs["coordinate_system"] == "BEAM"
+    assert {"velocity_beam1", "velocity_beam2", "velocity_beam3"}.issubset(
+        ds.data_vars
+    )
+    assert {"east_velocity", "north_velocity", "up_velocity"}.isdisjoint(
+        ds.data_vars
+    )
+    assert ds["velocity_beam1"].values.tolist() == [0.11, 0.12]
+    assert ds["velocity_beam1"].attrs["coordinate_system"] == "BEAM"
+    assert ds["velocity_beam1"].attrs["original_name"] == "velBeam1#1"
+
+
+def test_nortek_csv_explicit_enu_columns_use_standard_velocity_names(tmp_path):
+    csv_file = _write_nortek_csv_with_velocity_components(
+        tmp_path,
+        "ENU",
+        ("velEast#1", "velNorth#1", "velUp#1"),
+    )
+
+    ds = load_nortek_csv_data(csv_file)
+
+    assert ds.attrs["coordinate_system"] == "ENU"
+    assert {"east_velocity", "north_velocity", "up_velocity"}.issubset(ds.data_vars)
+    assert "velocity_east" not in ds.data_vars
+    assert ds["east_velocity"].values.tolist() == [0.11, 0.12]
+    assert ds["east_velocity"].attrs["original_name"] == "velEast#1"
+    assert ds["east_velocity"].attrs["coordinate_system"] == "ENU"
+
+
+def test_nortek_csv_explicit_xyz_columns_use_standard_velocity_names(tmp_path):
+    csv_file = _write_nortek_csv_with_velocity_components(
+        tmp_path,
+        "XYZ",
+        ("velX#1", "velY#1", "velZ#1"),
+    )
+
+    ds = load_nortek_csv_data(csv_file)
+
+    assert ds.attrs["coordinate_system"] == "XYZ"
+    assert {"x_velocity", "y_velocity", "z_velocity"}.issubset(ds.data_vars)
+    assert ds["x_velocity"].values.tolist() == [0.11, 0.12]
+    assert ds["x_velocity"].attrs["original_name"] == "velX#1"
+    assert ds["x_velocity"].attrs["coordinate_system"] == "XYZ"
 
 
 def test_nortek_csv_raw_metadata_matches_ascii_shape(tmp_path):

--- a/tests/readers/test_nortek_csv_reader.py
+++ b/tests/readers/test_nortek_csv_reader.py
@@ -181,7 +181,7 @@ def test_nortek_csv_metadata_files_set_coordinate_system_and_units(tmp_path):
     )
 
     assert ds.attrs["coordinate_system"] == "ENU"
-    assert {"east_velocity", "north_velocity", "up_velocity"}.issubset(ds.data_vars)
+    assert {"velocity_east", "velocity_north", "velocity_up"}.issubset(ds.data_vars)
     assert "velocity_beam1" not in ds.data_vars
     assert ds["east_velocity"].values.tolist() == [0.11, 0.12]
     assert ds["east_velocity"].attrs["coordinate_system"] == "ENU"
@@ -274,7 +274,7 @@ def test_nortek_csv_raw_metadata_matches_ascii_shape(tmp_path):
         [0, 0, -1],
     ]
     assert payload["blocks"]["units"]["vel"]["units"] == "m/s"
-    assert payload["variables"]["east_velocity"] == {
+    assert payload["variables"]["velocity_east"] == {
         "column_number": "11",
         "original_name": "velBeam1#1",
         "units": "m/s",

--- a/tests/readers/test_nortek_csv_reader.py
+++ b/tests/readers/test_nortek_csv_reader.py
@@ -210,7 +210,8 @@ def test_nortek_csv_metadata_files_set_coordinate_system_and_units(tmp_path):
     )
 
     assert ds.attrs["coordinate_system"] == "ENU"
-    assert {"velocity_east", "velocity_north", "velocity_up"}.issubset(ds.data_vars)
+    assert {"east_velocity", "north_velocity", "up_velocity"}.issubset(ds.data_vars)
+    assert "velocity_east" not in ds.data_vars
     assert "velocity_beam1" not in ds.data_vars
     assert ds["east_velocity"].values.tolist() == [0.11, 0.12]
     assert ds["east_velocity"].attrs["coordinate_system"] == "ENU"
@@ -358,7 +359,7 @@ def test_nortek_csv_raw_metadata_matches_ascii_shape(tmp_path):
         [0, 0, -1],
     ]
     assert payload["blocks"]["units"]["vel"]["units"] == "m/s"
-    assert payload["variables"]["velocity_east"] == {
+    assert payload["variables"]["east_velocity"] == {
         "column_number": "11",
         "original_name": "velBeam1#1",
         "units": "m/s",


### PR DESCRIPTION
Variables names e.g. "velEast#1 where not parsed. Two tests still fail, (also in the main branch) because the test file used is inconsistent: it has coordinate system "ENU" but variables named "velBeam1#1".