### PR TITLE
docs: Documentation accuracy sweep: formats, API reference

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -3,6 +3,29 @@ API Reference
 
 This section provides detailed API documentation for all SeaSenseLib modules.
 
+Top-Level API Functions
+-----------------------
+
+These convenience functions are the main entry points for most users and are available directly on the ``seasenselib`` package (commonly imported as ``ssl``).
+
+.. autofunction:: seasenselib.read
+
+.. autofunction:: seasenselib.write
+
+.. autofunction:: seasenselib.plot
+
+.. autofunction:: seasenselib.formats
+
+.. autofunction:: seasenselib.list_readers
+
+.. autofunction:: seasenselib.list_writers
+
+.. autofunction:: seasenselib.list_plotters
+
+.. autofunction:: seasenselib.list_parameters
+
+.. autofunction:: seasenselib.list_all
+
 Readers
 -------
 
@@ -121,6 +144,11 @@ Specific Reader Classes
    :undoc-members:
    :show-inheritance:
 
+.. autoclass:: seasenselib.readers.SbeHexReader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Writers
 -------
 
@@ -177,17 +205,12 @@ Specific Plotter Classes
    :undoc-members:
    :show-inheritance:
 
-.. autoclass:: seasenselib.plotters.ProfilePlotter
+.. autoclass:: seasenselib.plotters.DepthProfilePlotter
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. autoclass:: seasenselib.plotters.TimeSeriesPlotter
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. autoclass:: seasenselib.plotters.TimeSeriesPlotterMulti
    :members:
    :undoc-members:
    :show-inheritance:
@@ -224,3 +247,111 @@ Specific Processor Classes
    :members:
    :undoc-members:
    :show-inheritance:
+
+Pipeline System
+---------------
+
+The Level-1 processing pipeline transforms raw data into standardized, CF/ACDD-compliant datasets through a sequence of configurable stages. See the :doc:`user_guide` for a conceptual overview; the classes and factory functions below make up its public API.
+
+.. automodule:: seasenselib.pipeline
+   :no-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.Pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.Stage
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.StageContext
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.TransformationStage
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.PipelineConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.StageConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.pipeline.StageRegistry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autofunction:: seasenselib.pipeline.default_pipeline
+
+.. autofunction:: seasenselib.pipeline.minimal_pipeline
+
+.. autofunction:: seasenselib.pipeline.create_pipeline
+
+.. autofunction:: seasenselib.pipeline.list_available_pipelines
+
+Core Infrastructure
+-------------------
+
+Lower-level classes used by the readers, writers, and top-level API. Most users will not need these directly.
+
+.. autoclass:: seasenselib.core.DataIOManager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.core.FormatDetector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.core.ReaderFactory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.core.WriterFactory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Exceptions
+^^^^^^^^^^
+
+.. autoclass:: seasenselib.core.SeaSenseLibError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.core.FormatDetectionError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.core.DependencyError
+   :members:
+   :show-inheritance:
+
+.. autoclass:: seasenselib.core.ValidationError
+   :members:
+   :show-inheritance:
+
+Canonical Parameters
+--------------------
+
+``seasenselib.parameters`` defines the canonical (standardized) variable names used throughout SeaSenseLib — for example ``TEMPERATURE = 'temperature'`` and ``SALINITY = 'salinity'``. Reader mappings translate instrument-specific column names onto these canonical names.
+
+To list the canonical parameters available at runtime, use the top-level helper:
+
+.. code-block:: python
+
+   import seasenselib as ssl
+   ssl.list_parameters()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ For recommendations or bug reports, please visit https://github.com/ocean-uhh/se
    :caption: Getting started
 
    about
+   overview
    installation
 
 .. toctree::

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,11 +4,22 @@ Installation
 Requirements
 ------------
 
-SeaSenseLib requires Python 3.10 or later and depends on several scientific Python packages:
+SeaSenseLib requires Python 3.10 or later and depends on several scientific Python packages, all of which are installed automatically by ``pip``:
 
-* **Core dependencies**: xarray, pandas, numpy, matplotlib
-* **File format support**: netcdf4, pycnv, pyrsktools
-* **Scientific computing**: scipy, gsw (Gibbs SeaWater library)
+* **Core data handling**: xarray, pandas, numpy, scipy
+* **File format support**: netcdf4, pycnv, pyrsktools, seabirdscientific, mhkit (with the ``dolfyn`` extra, for Nortek/RDI raw data)
+* **Scientific computing**: gsw (Gibbs SeaWater library), pint (units)
+* **Plotting**: matplotlib, pylablib
+
+You do not need to install these individually — they come with SeaSenseLib.
+
+If you are new to Python, first check that Python 3.10+ is available:
+
+.. code-block:: bash
+
+   python3 --version
+
+If it reports a version below 3.10 (or the command is not found), install a current Python from `python.org <https://www.python.org/downloads/>`_ or via a distribution such as Miniconda (see below) before continuing.
 
 Install from PyPI
 -----------------
@@ -20,6 +31,25 @@ The easiest way to install SeaSenseLib is using pip:
    pip install seasenselib
 
 This will install SeaSenseLib and all required dependencies.
+
+Using conda or mamba
+--------------------
+
+Many oceanographers manage Python with Anaconda/Miniconda (``conda``) or its faster drop-in replacement ``mamba``. SeaSenseLib is not yet published on conda-forge, so you create a conda environment and then install SeaSenseLib into it with ``pip``:
+
+.. code-block:: bash
+
+   # with conda
+   conda create -n seasenselib python=3.11
+   conda activate seasenselib
+   pip install seasenselib
+
+   # or with mamba (same commands, faster solver)
+   mamba create -n seasenselib python=3.11
+   mamba activate seasenselib
+   pip install seasenselib
+
+Installing with ``pip`` inside an activated conda environment is expected and supported here. Do not run ``conda install seasenselib`` — the package is not on any conda channel and that command will fail.
 
 Development Installation
 ------------------------
@@ -63,7 +93,21 @@ If you want to contribute to the project or modify the code, follow these steps:
       pip install --upgrade pip setuptools wheel
       pip install -e ".[dev]"
 
-   This installs SeaSenseLib in "editable" mode along with development dependencies like pytest and sphinx.
+   This installs SeaSenseLib in "editable" mode (changes to the source take effect immediately without reinstalling). The ``[dev]`` part is an optional dependency group that adds tools needed only for development — pytest (running tests), sphinx, nbsphinx, myst-parser and the RTD theme (building these docs), plus build and twine (packaging). A plain ``pip install -e .`` skips those.
+
+   The same editable install works inside a conda/mamba environment: activate the environment first, then run the ``pip install -e ".[dev]"`` command.
+
+**Using the conda environment file:**
+
+For development with conda, the repository provides an ``environment.yml`` that creates an environment named ``seasenselib`` with Python (3.10–3.13), ``gsw``, ``pandoc``, and all runtime and development dependencies:
+
+.. code-block:: bash
+
+   conda env create -f environment.yml
+   conda activate seasenselib
+   pip install -e .
+
+The environment file installs the dependencies but not SeaSenseLib itself, so the final ``pip install -e .`` installs the package in editable mode from the repository root.
 
 Alternative Installation Methods
 --------------------------------
@@ -111,7 +155,9 @@ This should display the available commands and options.
 
 .. code-block:: bash
 
-   python -m unittest discover tests/
+   python -m pytest tests/
+
+(``python -m unittest discover tests/`` also works if you prefer the standard library test runner.)
 
 Troubleshooting
 ---------------

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,5 +1,74 @@
-SeaSenseLib overview
-===============================
+SeaSenseLib Overview
+====================
 
+SeaSenseLib reads oceanographic sensor data from many instrument formats, standardizes it, and lets you convert or visualize it — all through a single, consistent interface built on `xarray <https://docs.xarray.dev/>`_ Datasets.
 
-Some notes about how to use the SeaSenseLib package, and where it fits into a data processing pipeline.
+This page describes how the pieces fit together. For installation see :doc:`installation`, for the full list of formats see :doc:`supported_formats`, and for detailed signatures see :doc:`api_reference`.
+
+Where it fits in a data workflow
+--------------------------------
+
+A typical SeaSenseLib workflow has three steps:
+
+1. **Read** a raw instrument file into an xarray ``Dataset``. During reading, an optional processing *pipeline* normalizes variable names and units, derives parameters, and adds CF/ACDD-compliant metadata.
+2. **Process** the Dataset further if needed — subset, resample, or compute statistics — using standard xarray operations or the built-in processors.
+3. **Write** the Dataset to a standard format (NetCDF, CSV, Excel), or **plot** it (depth profile, time series, T-S diagram).
+
+::
+
+   raw instrument file
+          │
+          ▼
+     ssl.read()  ──►  xarray.Dataset  ──►  ssl.write()  ──►  .nc / .csv / .xlsx
+        (+ pipeline)        │
+                            └──────────►  ssl.plot()   ──►  figure
+
+A minimal example
+-----------------
+
+.. code-block:: python
+
+   import seasenselib as ssl
+
+   # Read a SeaBird CNV file. Format is auto-detected from the extension.
+   ds = ssl.read("station001.cnv")
+
+   # Inspect it — it is a standard xarray Dataset.
+   print(ds)
+
+   # Write it out as a CF-compliant NetCDF file.
+   ssl.write(ds, "station001.nc", file_format="netcdf")
+
+   # Or make a T-S diagram.
+   ssl.plot("ts-diagram", ds, output_file="station001_ts.png")
+
+When automatic format detection is not enough (ambiguous extensions such as ``.mat`` or ``.hex``), pass an explicit ``file_format`` key — see :doc:`supported_formats`.
+
+The processing pipeline
+-----------------------
+
+By default, reading applies a processing pipeline that turns raw data into a standardized Level-1 dataset. You can choose how much processing to apply with the ``pipeline_profile`` argument:
+
+.. code-block:: python
+
+   ds = ssl.read("station001.cnv", pipeline_profile="minimal")  # mapping only
+   ds = ssl.read("station001.cnv", pipeline_profile="default")  # conservative L1
+   ds = ssl.read("station001.cnv", pipeline_profile="full")     # all stages
+
+- ``minimal`` — variable-name mapping and finalization only.
+- ``default`` — conservative Level-1 processing (no unit conversion).
+- ``full`` — the complete Level-1 pipeline with all stages and handlers.
+
+For raw, unprocessed data, use the CLI ``--raw-only`` flag or skip the pipeline stages you do not want. The pipeline is fully configurable; its stages, profiles, and public API are described in :doc:`user_guide` and :doc:`api_reference`.
+
+Command-line interface
+----------------------
+
+Everything above is also available from the command line:
+
+.. code-block:: bash
+
+   seasenselib convert -i station001.cnv -o station001.nc
+   seasenselib list readers
+
+Run ``seasenselib --help`` to see all commands.

--- a/docs/source/supported_formats.rst
+++ b/docs/source/supported_formats.rst
@@ -103,6 +103,11 @@ Format keys can be used with ``ssl.read(filename, file_format='key')`` when auto
      - ``sbe-cnv``
      - SeaBird CNV format (CTD profiles)
    * - SeaBird
+     - SBE 911plus / 917plus
+     - ``.hex``
+     - ``sbe-hex``
+     - SeaBird raw HEX (CTD profiles); the SBE 9 family is auto-detected from the ``* Sea-Bird SBE 9 Data File`` header
+   * - SeaBird
      - SBE16 Seacat
      - ``.cnv``
      - ``sbe-cnv``
@@ -137,6 +142,46 @@ Format keys can be used with ``ssl.read(filename, file_format='key')`` when auto
      - ``.000``, ``.PD0``, ``.ENR``, ``.ENS``, ``.ENX``
      - ``rdi-raw``
      - RDI raw binary ADCP files
+
+Output Formats (Writers)
+------------------------
+
+SeaSenseLib can write an xarray ``Dataset`` back out to several formats with ``ssl.write(dataset, filename, file_format='key')``.
+
+.. list-table:: Supported Output Formats
+   :header-rows: 1
+   :widths: 15 20 20
+
+   * - Format
+     - Format Key
+     - File Extension
+   * - NetCDF
+     - ``netcdf``
+     - ``.nc``
+   * - CSV
+     - ``csv``
+     - ``.csv``
+   * - Excel
+     - ``excel``
+     - ``.xlsx``
+
+Plot Types (Plotters)
+---------------------
+
+SeaSenseLib provides several plot types via ``ssl.plot(plotter_key, dataset, ...)``.
+
+.. list-table:: Supported Plot Types
+   :header-rows: 1
+   :widths: 20 40
+
+   * - Plot Type
+     - Plotter Key
+   * - Depth profile
+     - ``depth-profile``
+   * - Time series
+     - ``time-series``
+   * - T-S diagram
+     - ``ts-diagram``
 
 Usage Examples
 --------------
@@ -209,7 +254,7 @@ Format Detection Summary
 **Auto-detected formats** (unique file extensions):
    
 - ``.cnv`` → ``sbe-cnv`` (SeaBird CNV files)
-- ``.hex`` → ``sbe-hex`` (SeaBird SBE37 HEX files)
+- ``.hex`` → ``sbe-hex`` (SeaBird SBE37 and SBE 911plus/917plus HEX files)
 - ``.rsk`` → ``rbr-rsk`` (RBR RSK files - automatically selects modern/legacy reader)
 - ``.nc`` → ``netcdf`` (NetCDF files)
 - ``.csv`` → ``csv`` (CSV files)

--- a/seasenselib/plotters/depth_profile_plotter.py
+++ b/seasenselib/plotters/depth_profile_plotter.py
@@ -20,8 +20,7 @@ class DepthProfilePlotter(AbstractPlotter):
     
     Methods:
     --------
-    plot(output_file=None, title='Salinity and Temperature Profiles', 
-         show_grid=True, dot_size=3, show_lines_between_dots=True):
+    plot(output_file=None, title='Salinity and Temperature Profiles', show_grid=True, dot_size=3, show_lines_between_dots=True)
         Creates and displays/saves the vertical profile plot.
     """
 
@@ -43,7 +42,7 @@ class DepthProfilePlotter(AbstractPlotter):
             Size of the scatter plot markers.
         show_lines_between_dots : bool, default True
             Whether to connect data points with lines.
-        **kwargs : dict
+        \*\*kwargs : dict
             Additional keyword arguments (for compatibility).
             
         Raises:

--- a/seasenselib/plotters/depth_profile_plotter.py
+++ b/seasenselib/plotters/depth_profile_plotter.py
@@ -20,7 +20,7 @@ class DepthProfilePlotter(AbstractPlotter):
     
     Methods:
     --------
-    plot(output_file=None, title='Salinity and Temperature Profiles', show_grid=True, dot_size=3, show_lines_between_dots=True)
+    ``plot(output_file=None, title='Salinity and Temperature Profiles', show_grid=True, dot_size=3, show_lines_between_dots=True, *args, **kwargs)``
         Creates and displays/saves the vertical profile plot.
     """
 


### PR DESCRIPTION
Brings the Sphinx docs back in line with the current codebase after a full sweep. Findings were verified against the source (not taken from memory): the readers table was already current, but the writer/plotter tables were missing, the API reference had two stale/broken class references, the install page stated the wrong Python version and omitted conda/mamba, and the overview page was a stub.

## Supported formats

Added an Output Formats (Writers) table (`netcdf`, `csv`, `excel`) and a Plot Types (Plotters) table (`depth-profile`, `time-series`, `ts-diagram`). Keys and file extensions verified against `ssl.list_writers()` / `ssl.list_plotters()`.

Added an SBE 911plus/917plus `.hex` → `sbe-hex` row and corrected the format-detection summary, since `SbeHexReader` auto-detects the SBE 9 family from the `* Sea-Bird SBE 9 Data File` header (verified in `seasenselib/readers/sbe_hex_reader.py`).

The readers table was left unchanged — it was already complete and current (all three RBR RSK variants, `sbe-hex`, `rdi-raw`, `nortek-raw` present).

## API reference

Fixed two broken autodoc references that Sphinx was silently skipping: `ProfilePlotter` → `DepthProfilePlotter`, and removed `TimeSeriesPlotterMulti` (no such class exists). Added the missing `SbeHexReader`.

Added a Top-Level API Functions section documenting the nine public entry points (`read`, `write`, `plot`, `formats`, `list_readers`, `list_writers`, `list_plotters`, `list_parameters`, `list_all`) — all verified importable at `seasenselib.<name>`.

Added Pipeline System, Core Infrastructure, and Canonical Parameters sections. `parameters.py` is documented with prose pointing to `ssl.list_parameters()` rather than an `automodule` dump, since it is a flat list of string constants with no module docstring.

## Installation

Corrected the required Python version from the stale 3.7 to 3.10, matching `pyproject.toml`'s `requires-python = ">=3.10"` (after rebasing on the concurrent change that raised the floor to 3.10), in both the Requirements section and Troubleshooting. Corrected the dependency list to match `pyproject.toml` (added `seabirdscientific`, `mhkit[dolfyn]`, `pint`, `pylablib`).

Added a conda/mamba environment section for users on Anaconda/Miniconda, with an explicit note that SeaSenseLib is not on conda-forge so `pip install` inside an activated conda env is the supported path (and `conda install seasenselib` will fail). Explained what the `.[dev]` extra installs, added a newcomer `python3 --version` check, and switched the recommended test command to `pytest`.

## Overview

Replaced the five-line stub with a real overview: where SeaSenseLib fits in a read → process → write/plot workflow, a minimal end-to-end example, the pipeline profiles (`minimal` / `default` / `full`), and CLI usage. The CLI example uses the actual `convert -i ... -o ...` flag form (verified against `seasenselib convert --help`). Wired `overview` into the `index.rst` toctree, where it was previously orphaned.

## Code change

Fixed RST formatting in the `DepthProfilePlotter` docstring (`seasenselib/plotters/depth_profile_plotter.py`), exposed once the API reference began rendering it: escaped the `**kwargs` in the Parameters section, and rewrote the "Methods" signature as a single-line inline literal that includes `*args, **kwargs` so it matches the actual `plot()` signature and avoids reST `*`/`**` parsing.

## Known follow-up (not in this PR)

Documenting the pipeline/core/api/writers/plotters modules for the first time surfaced ~40 pre-existing RST formatting bugs in their code docstrings (unclosed `**bold**`, block quotes without blank lines, two `Unexpected indentation` errors). These are latent bugs unrelated to the doc-page content and are deferred to a dedicated `[FIX] docstring RST cleanup` branch.